### PR TITLE
feat(docs): redesign GitHub Pages site with editorial aesthetic

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,96 +1,93 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Markdown to ServiceNow — Chrome Extension</title>
   <meta name="description" content="Convert Markdown to ServiceNow journal format instantly. Features popup converter, right-click context menu, in-page toolbar, live preview, custom alerts, and snippets manager." />
-  <!-- Open Graph -->
   <meta property="og:title" content="Markdown to ServiceNow — Chrome Extension" />
   <meta property="og:description" content="Write in Markdown, post to ServiceNow. A Chrome extension with popup converter, context menu, in-page toolbar, live preview, and custom alerts." />
   <meta property="og:type" content="website" />
-  <!-- TODO(user): Update og:url once GitHub Pages is live -->
   <meta property="og:url" content="https://yadav-prakhar.github.io/markdown-sn-extension/" />
-  <!-- TODO(user): Create a social preview image (1200x630px) and update this path -->
-  <!-- <meta property="og:image" content="https://yadav-prakhar.github.io/markdown-sn-extension/social-preview.png" /> -->
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="icon" type="image/png" href="icons/Icon128.png" />
   <link rel="icon" type="image/svg+xml" href="icons/Icon.svg" />
 
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
   <style>
     /* ============================================================
-       DESIGN SYSTEM — CSS Custom Properties
+       DESIGN TOKENS
        ============================================================ */
     :root {
-      --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-      --font-mono: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', Consolas, monospace;
+      --font-display: 'Instrument Serif', Georgia, serif;
+      --font-body:    'DM Sans', system-ui, sans-serif;
+      --font-mono:    'JetBrains Mono', 'Fira Code', Consolas, monospace;
 
-      /* Spacing */
-      --space-xs: 0.25rem;
-      --space-sm: 0.5rem;
-      --space-md: 1rem;
-      --space-lg: 1.5rem;
-      --space-xl: 2rem;
+      --space-xs:  0.25rem;
+      --space-sm:  0.5rem;
+      --space-md:  1rem;
+      --space-lg:  1.5rem;
+      --space-xl:  2rem;
       --space-2xl: 3rem;
       --space-3xl: 5rem;
 
-      /* Radius */
-      --radius-sm: 4px;
-      --radius-md: 8px;
-      --radius-lg: 12px;
-      --radius-xl: 16px;
+      --radius-sm:   3px;
+      --radius-md:   6px;
+      --radius-lg:   10px;
+      --radius-xl:   16px;
       --radius-full: 9999px;
 
-      /* Transitions */
-      --transition: 0.2s ease;
-    }
-
-    [data-theme="dark"] {
-      --bg: #0d1117;
-      --bg-secondary: #161b22;
-      --bg-tertiary: #1f2937;
-      --surface: #21262d;
-      --surface-hover: #30363d;
-      --border: #30363d;
-      --border-muted: #21262d;
-      --text: #e6edf3;
-      --text-secondary: #8b949e;
-      --text-muted: #6e7681;
-      --accent: #58a6ff;
-      --accent-hover: #79b8ff;
-      --accent-purple: #bc8cff;
-      --accent-teal: #3fb950;
-      --accent-orange: #f0883e;
-      --gradient: linear-gradient(135deg, #8250df 0%, #388bfd 50%, #1f6feb 100%);
-      --gradient-subtle: linear-gradient(135deg, rgba(130,80,223,0.15) 0%, rgba(56,139,253,0.15) 100%);
-      --shadow: 0 4px 24px rgba(0,0,0,0.4);
-      --shadow-lg: 0 8px 48px rgba(0,0,0,0.6);
-      --code-bg: #161b22;
-      --overlay: rgba(0,0,0,0.85);
+      --transition:      0.18s ease;
+      --transition-slow: 0.32s ease;
     }
 
     [data-theme="light"] {
-      --bg: #ffffff;
-      --bg-secondary: #f6f8fa;
-      --bg-tertiary: #f0f2f5;
-      --surface: #ffffff;
-      --surface-hover: #f0f2f5;
-      --border: #d0d7de;
-      --border-muted: #e8eaed;
-      --text: #24292f;
-      --text-secondary: #57606a;
-      --text-muted: #8c959f;
-      --accent: #0969da;
-      --accent-hover: #0550ae;
-      --accent-purple: #8250df;
-      --accent-teal: #1a7f37;
-      --accent-orange: #bc4c00;
-      --gradient: linear-gradient(135deg, #8250df 0%, #0969da 50%, #1a7f37 100%);
-      --gradient-subtle: linear-gradient(135deg, rgba(130,80,223,0.08) 0%, rgba(9,105,218,0.08) 100%);
-      --shadow: 0 4px 16px rgba(0,0,0,0.08);
-      --shadow-lg: 0 8px 32px rgba(0,0,0,0.12);
-      --code-bg: #f6f8fa;
-      --overlay: rgba(0,0,0,0.6);
+      --bg:             #F9F6F1;
+      --bg-secondary:   #F2EDE4;
+      --bg-tertiary:    #EAE3D6;
+      --surface:        #FDFCFA;
+      --surface-hover:  #F2EDE4;
+      --border:         #D8D0C4;
+      --border-muted:   #E8E2D9;
+      --text:           #1C1714;
+      --text-secondary: #5C5550;
+      --text-muted:     #9B938A;
+      --accent:         #C84B31;
+      --accent-hover:   #A83B23;
+      --accent-subtle:  rgba(200,75,49,0.08);
+      --accent-green:   #2D6A4F;
+      --accent-gold:    #B45309;
+      --code-bg:        #EFE9DE;
+      --overlay:        rgba(28,23,20,0.65);
+      --shadow:         0 2px 12px rgba(28,23,20,0.07);
+      --shadow-lg:      0 6px 32px rgba(28,23,20,0.10);
+      --shadow-xl:      0 16px 56px rgba(28,23,20,0.14);
+    }
+
+    [data-theme="dark"] {
+      --bg:             #171310;
+      --bg-secondary:   #1E1A17;
+      --bg-tertiary:    #252119;
+      --surface:        #28231F;
+      --surface-hover:  #322C28;
+      --border:         #3C3530;
+      --border-muted:   #2A2420;
+      --text:           #F0EAE2;
+      --text-secondary: #A89D94;
+      --text-muted:     #6E6560;
+      --accent:         #E8623D;
+      --accent-hover:   #F07555;
+      --accent-subtle:  rgba(232,98,61,0.12);
+      --accent-green:   #4ADE80;
+      --accent-gold:    #F59E0B;
+      --code-bg:        #1E1A17;
+      --overlay:        rgba(0,0,0,0.82);
+      --shadow:         0 2px 12px rgba(0,0,0,0.45);
+      --shadow-lg:      0 6px 32px rgba(0,0,0,0.55);
+      --shadow-xl:      0 16px 56px rgba(0,0,0,0.65);
     }
 
     /* ============================================================
@@ -101,76 +98,170 @@
     html { scroll-behavior: smooth; font-size: 16px; }
 
     body {
-      font-family: var(--font);
+      font-family: var(--font-body);
       background: var(--bg);
       color: var(--text);
-      line-height: 1.6;
+      line-height: 1.65;
       transition: background var(--transition), color var(--transition);
       overflow-x: hidden;
     }
 
     img { max-width: 100%; height: auto; display: block; }
-    a { color: var(--accent); text-decoration: none; }
+
+    a { color: var(--accent); text-decoration: none; transition: color var(--transition); }
     a:hover { color: var(--accent-hover); text-decoration: underline; }
+
     code {
       font-family: var(--font-mono);
-      font-size: 0.875em;
+      font-size: 0.82em;
       background: var(--code-bg);
       border: 1px solid var(--border);
       border-radius: var(--radius-sm);
-      padding: 0.1em 0.4em;
+      padding: 0.12em 0.42em;
     }
+
     pre {
       font-family: var(--font-mono);
-      font-size: 0.875rem;
+      font-size: 0.85rem;
       background: var(--code-bg);
       border: 1px solid var(--border);
       border-radius: var(--radius-md);
-      padding: var(--space-md);
+      padding: var(--space-lg);
       overflow-x: auto;
       white-space: pre-wrap;
       word-break: break-word;
+      line-height: 1.7;
     }
     pre code { background: none; border: none; padding: 0; font-size: inherit; }
 
     /* ============================================================
-       LAYOUT UTILITIES
+       LAYOUT
        ============================================================ */
     .container {
       max-width: 1100px;
       margin: 0 auto;
       padding: 0 var(--space-xl);
     }
-    .section {
-      padding: var(--space-3xl) 0;
+
+    .section { padding: var(--space-3xl) 0; }
+    .section + .section { border-top: 1px solid var(--border-muted); }
+
+    .section-eyebrow {
+      display: flex;
+      align-items: center;
+      gap: var(--space-md);
+      margin-bottom: var(--space-lg);
     }
-    .section + .section {
-      border-top: 1px solid var(--border-muted);
-    }
-    .section-label {
-      font-size: 0.8rem;
-      font-weight: 600;
+    .section-tag {
+      font-family: var(--font-mono);
+      font-size: 0.7rem;
+      font-weight: 500;
       text-transform: uppercase;
-      letter-spacing: 0.12em;
+      letter-spacing: 0.15em;
       color: var(--accent);
-      margin-bottom: var(--space-sm);
+      white-space: nowrap;
     }
+    .section-tag-line {
+      flex: 1;
+      height: 1px;
+      background: var(--border);
+    }
+
     .section-title {
-      font-size: clamp(1.75rem, 4vw, 2.5rem);
-      font-weight: 700;
-      line-height: 1.2;
+      font-family: var(--font-display);
+      font-size: clamp(1.9rem, 4.5vw, 2.75rem);
+      font-weight: 400;
+      line-height: 1.15;
+      letter-spacing: -0.01em;
       margin-bottom: var(--space-md);
-      letter-spacing: -0.02em;
     }
+    .section-title em { font-style: italic; color: var(--accent); }
+
     .section-subtitle {
-      font-size: 1.125rem;
+      font-size: 1.05rem;
       color: var(--text-secondary);
-      max-width: 600px;
+      max-width: 560px;
+      line-height: 1.72;
       margin-bottom: var(--space-2xl);
     }
-    .grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: var(--space-xl); }
-    .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-lg); }
-    .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--space-md); }
+
+    .grid-2 { display: grid; grid-template-columns: repeat(2,1fr); gap: var(--space-xl); }
+    .grid-3 { display: grid; grid-template-columns: repeat(3,1fr); gap: var(--space-lg); }
+
+    /* ============================================================
+       BUTTONS
+       ============================================================ */
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      padding: 0.6rem 1.25rem;
+      border-radius: var(--radius-sm);
+      font-family: var(--font-body);
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all var(--transition);
+      border: 1.5px solid transparent;
+      text-decoration: none;
+      white-space: nowrap;
+    }
+    .btn:hover { text-decoration: none; }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #fff;
+      border-color: var(--accent);
+    }
+    .btn-primary:hover {
+      background: var(--accent-hover);
+      border-color: var(--accent-hover);
+      color: #fff;
+      transform: translateY(-1px);
+      box-shadow: 0 4px 14px rgba(200,75,49,0.28);
+    }
+
+    .btn-secondary {
+      background: transparent;
+      color: var(--text);
+      border-color: var(--border);
+    }
+    .btn-secondary:hover {
+      background: var(--bg-secondary);
+      border-color: var(--text-muted);
+      color: var(--text);
+    }
+
+    .btn-ghost {
+      background: transparent;
+      color: var(--text-secondary);
+      border-color: transparent;
+      padding: 0.5rem;
+      border-radius: var(--radius-md);
+    }
+    .btn-ghost:hover { background: var(--bg-secondary); color: var(--text); }
+
+    .btn-lg { padding: 0.8rem 1.75rem; font-size: 0.95rem; }
+
+    .theme-toggle { font-size: 1rem; }
+
+    .hamburger {
+      display: none;
+      flex-direction: column;
+      gap: 5px;
+      cursor: pointer;
+      padding: 8px;
+      background: none;
+      border: none;
+    }
+    .hamburger span {
+      display: block;
+      width: 20px;
+      height: 1.5px;
+      background: var(--text);
+      border-radius: 2px;
+      transition: all var(--transition);
+    }
 
     /* ============================================================
        NAVIGATION
@@ -180,28 +271,34 @@
       top: 0;
       z-index: 100;
       background: var(--bg);
-      border-bottom: 1px solid var(--border);
-      backdrop-filter: blur(12px);
-      -webkit-backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--border-muted);
     }
+
     .nav-inner {
       display: flex;
       align-items: center;
       gap: var(--space-xl);
-      height: 60px;
+      height: 56px;
     }
+
     .nav-logo {
       display: flex;
       align-items: center;
-      gap: var(--space-sm);
-      font-weight: 700;
-      font-size: 1rem;
-      color: var(--text);
+      gap: 0.5rem;
       text-decoration: none;
       flex-shrink: 0;
+      color: var(--text);
     }
-    .nav-logo img { width: 24px; height: 24px; border-radius: var(--radius-sm); }
-    .nav-logo:hover { text-decoration: none; color: var(--accent); }
+    .nav-logo:hover { text-decoration: none; color: var(--text); }
+    .nav-logo img { width: 26px; height: 26px; border-radius: var(--radius-sm); }
+    .nav-logo-text {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      font-weight: 500;
+      color: var(--text);
+    }
+    .nav-logo-arrow { color: var(--accent); }
+
     .nav-links {
       display: flex;
       align-items: center;
@@ -210,76 +307,50 @@
       flex: 1;
     }
     .nav-links a {
-      font-size: 0.9rem;
+      font-size: 0.85rem;
       color: var(--text-secondary);
       text-decoration: none;
       transition: color var(--transition);
     }
     .nav-links a:hover { color: var(--text); }
+    .nav-links a.nav-active { color: var(--text); }
+
     .nav-actions {
       display: flex;
       align-items: center;
       gap: var(--space-sm);
       flex-shrink: 0;
     }
-    .btn {
-      display: inline-flex;
-      align-items: center;
-      gap: var(--space-xs);
-      padding: 0.5rem 1rem;
-      border-radius: var(--radius-full);
-      font-size: 0.875rem;
-      font-weight: 600;
-      cursor: pointer;
-      transition: all var(--transition);
-      border: none;
-      text-decoration: none;
-      font-family: var(--font);
-    }
-    .btn-primary {
-      background: var(--gradient);
-      color: #fff;
-    }
-    .btn-primary:hover {
-      opacity: 0.9;
-      transform: translateY(-1px);
-      text-decoration: none;
-      color: #fff;
-    }
-    .btn-secondary {
-      background: transparent;
-      color: var(--text);
-      border: 1px solid var(--border);
-    }
-    .btn-secondary:hover {
-      background: var(--surface-hover);
-      text-decoration: none;
-      color: var(--text);
-    }
-    .btn-ghost {
-      background: transparent;
-      color: var(--text-secondary);
-      padding: 0.5rem;
-      border-radius: var(--radius-md);
-    }
-    .btn-ghost:hover { background: var(--surface-hover); color: var(--text); text-decoration: none; }
-    .btn-lg {
-      padding: 0.75rem 1.5rem;
-      font-size: 1rem;
-      border-radius: var(--radius-full);
-    }
-    .theme-toggle { font-size: 1.1rem; line-height: 1; }
-    .hamburger { display: none; flex-direction: column; gap: 4px; cursor: pointer; padding: 6px; }
-    .hamburger span { display: block; width: 20px; height: 2px; background: var(--text); border-radius: 2px; transition: all var(--transition); }
 
     /* ============================================================
        HERO
        ============================================================ */
     .hero {
-      padding: var(--space-3xl) 0 var(--space-2xl);
-      text-align: center;
-      background: radial-gradient(ellipse 80% 50% at 50% -10%, rgba(130,80,223,0.15) 0%, transparent 70%);
+      padding: calc(var(--space-3xl) * 1.1) 0 var(--space-3xl);
+      position: relative;
+      overflow: hidden;
     }
+
+    .hero-glow {
+      position: absolute;
+      top: -15%;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 860px;
+      height: 560px;
+      background: radial-gradient(ellipse, rgba(200,75,49,0.08) 0%, rgba(180,83,9,0.05) 40%, transparent 70%);
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    .hero > .container { position: relative; z-index: 1; }
+
+    .hero-inner {
+      text-align: center;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+
     .hero-badge {
       display: inline-flex;
       align-items: center;
@@ -287,143 +358,181 @@
       background: var(--bg-secondary);
       border: 1px solid var(--border);
       border-radius: var(--radius-full);
-      padding: 0.35rem 0.75rem;
-      font-size: 0.8rem;
+      padding: 0.28rem 0.8rem;
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
+      letter-spacing: 0.1em;
       color: var(--text-secondary);
-      margin-bottom: var(--space-lg);
+      margin-bottom: var(--space-xl);
+      text-transform: uppercase;
     }
     .hero-badge-dot {
-      width: 6px; height: 6px;
-      background: var(--accent-teal);
+      width: 5px; height: 5px;
+      background: var(--accent-green);
       border-radius: 50%;
-      animation: pulse 2s infinite;
+      animation: pulse 2.5s ease infinite;
     }
     @keyframes pulse {
       0%, 100% { opacity: 1; transform: scale(1); }
-      50% { opacity: 0.6; transform: scale(0.8); }
+      50%       { opacity: 0.4; transform: scale(0.65); }
     }
+
     .hero-icon {
-      width: 128px; height: 128px;
-      border-radius: var(--radius-xl);
-      margin: 0 auto var(--space-lg);
+      width: 88px; height: 88px;
+      border-radius: var(--radius-lg);
+      margin: 0 auto var(--space-xl);
+      box-shadow: var(--shadow-lg), 0 0 0 6px var(--bg-secondary), 0 0 0 8px var(--border);
     }
+
     .hero-title {
-      font-size: clamp(2.5rem, 7vw, 4rem);
-      font-weight: 800;
-      line-height: 1.1;
-      letter-spacing: -0.03em;
+      font-family: var(--font-display);
+      font-size: clamp(2.75rem, 8vw, 5rem);
+      font-weight: 400;
+      line-height: 1.06;
+      letter-spacing: -0.02em;
       margin-bottom: var(--space-lg);
     }
-    .hero-title .gradient-text {
-      background: var(--gradient);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
+    .hero-title-accent {
+      font-style: italic;
+      color: var(--accent);
     }
+
     .hero-subtitle {
-      font-size: 1.2rem;
+      font-size: 1.08rem;
       color: var(--text-secondary);
-      max-width: 560px;
+      max-width: 510px;
       margin: 0 auto var(--space-xl);
-      line-height: 1.7;
+      line-height: 1.78;
     }
+
     .hero-actions {
       display: flex;
       justify-content: center;
       gap: var(--space-md);
       flex-wrap: wrap;
-      margin-bottom: var(--space-xl);
+      margin-bottom: var(--space-lg);
     }
+
     .hero-shortcut {
-      display: inline-flex;
+      display: flex;
       align-items: center;
-      gap: var(--space-sm);
-      font-size: 0.875rem;
+      justify-content: center;
+      gap: 0.35rem;
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
       color: var(--text-muted);
+      letter-spacing: 0.06em;
       margin-bottom: var(--space-2xl);
     }
+
     .kbd {
       display: inline-flex;
       align-items: center;
       background: var(--surface);
       border: 1px solid var(--border);
       border-bottom-width: 2px;
-      border-radius: var(--radius-sm);
-      padding: 0.1rem 0.4rem;
+      border-radius: 3px;
+      padding: 0.05rem 0.38rem;
       font-family: var(--font-mono);
-      font-size: 0.75rem;
+      font-size: 0.68rem;
       color: var(--text-secondary);
     }
+
     .hero-stats {
       display: flex;
-      justify-content: center;
-      gap: var(--space-2xl);
-      flex-wrap: wrap;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      background: var(--surface);
+      max-width: 520px;
+      margin: 0 auto;
     }
-    .hero-stat { text-align: center; }
+    .hero-stat {
+      flex: 1;
+      text-align: center;
+      padding: var(--space-lg) var(--space-xl);
+      position: relative;
+    }
+    .hero-stat + .hero-stat::before {
+      content: '';
+      position: absolute;
+      left: 0; top: 22%; height: 56%;
+      width: 1px;
+      background: var(--border);
+    }
     .hero-stat-value {
-      font-size: 1.75rem;
-      font-weight: 800;
-      color: var(--text);
+      font-family: var(--font-display);
+      font-size: 2rem;
       line-height: 1;
+      margin-bottom: var(--space-xs);
+      color: var(--text);
     }
     .hero-stat-label {
-      font-size: 0.8rem;
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
       color: var(--text-muted);
-      margin-top: var(--space-xs);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
     }
 
     /* ============================================================
        FEATURES GRID
        ============================================================ */
-    .feature-card {
-      background: var(--bg-secondary);
+    .features-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
       border: 1px solid var(--border);
       border-radius: var(--radius-lg);
-      padding: var(--space-xl);
-      transition: all var(--transition);
-      position: relative;
       overflow: hidden;
     }
-    .feature-card::before {
-      content: '';
-      position: absolute;
-      top: 0; left: 0; right: 0;
-      height: 2px;
-      background: var(--gradient);
-      opacity: 0;
-      transition: opacity var(--transition);
+
+    .feature-card {
+      padding: var(--space-xl);
+      border-right: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+      background: var(--surface);
+      transition: background var(--transition);
     }
-    .feature-card:hover {
-      border-color: var(--surface-hover);
-      transform: translateY(-2px);
-      box-shadow: var(--shadow);
-    }
-    .feature-card:hover::before { opacity: 1; }
-    .feature-icon {
-      font-size: 2rem;
-      margin-bottom: var(--space-md);
+    .feature-card:nth-child(3n)       { border-right: none; }
+    .feature-card:nth-last-child(-n+3) { border-bottom: none; }
+    .feature-card:hover { background: var(--bg-secondary); }
+
+    .feature-num {
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
+      color: var(--accent);
+      letter-spacing: 0.12em;
       display: block;
+      margin-bottom: var(--space-lg);
+    }
+    .feature-icon {
+      font-size: 1.55rem;
+      display: block;
+      margin-bottom: var(--space-md);
     }
     .feature-title {
-      font-size: 1.05rem;
-      font-weight: 700;
+      font-weight: 600;
+      font-size: 0.93rem;
       margin-bottom: var(--space-sm);
-      color: var(--text);
+      letter-spacing: -0.01em;
     }
     .feature-desc {
-      font-size: 0.9rem;
+      font-size: 0.875rem;
       color: var(--text-secondary);
-      line-height: 1.6;
+      line-height: 1.65;
     }
     .feature-tag {
       display: inline-block;
-      background: rgba(130,80,223,0.15);
-      color: var(--accent-purple);
-      border-radius: var(--radius-full);
-      padding: 0.15rem 0.5rem;
-      font-size: 0.75rem;
-      font-weight: 600;
+      background: var(--accent-subtle);
+      color: var(--accent);
+      border: 1px solid rgba(200,75,49,0.18);
+      border-radius: 2px;
+      padding: 0.08rem 0.4rem;
+      font-family: var(--font-mono);
+      font-size: 0.62rem;
+      font-weight: 500;
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
       margin-top: var(--space-sm);
     }
 
@@ -432,21 +541,21 @@
        ============================================================ */
     .screenshots-grid {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: var(--space-lg);
+      grid-template-columns: repeat(3,1fr);
+      gap: var(--space-md);
     }
     .screenshot-card {
       border: 1px solid var(--border);
-      border-radius: var(--radius-lg);
+      border-radius: var(--radius-md);
       overflow: hidden;
-      cursor: pointer;
+      cursor: zoom-in;
       transition: all var(--transition);
       background: var(--bg-secondary);
     }
     .screenshot-card:hover {
       border-color: var(--accent);
-      transform: translateY(-3px);
       box-shadow: var(--shadow-lg);
+      transform: translateY(-2px);
     }
     .screenshot-card img {
       width: 100%;
@@ -455,10 +564,13 @@
       object-position: top;
     }
     .screenshot-caption {
-      padding: var(--space-md);
-      font-size: 0.875rem;
-      color: var(--text-secondary);
+      padding: 0.55rem var(--space-md);
+      font-family: var(--font-mono);
+      font-size: 0.67rem;
+      color: var(--text-muted);
       text-align: center;
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
       border-top: 1px solid var(--border-muted);
     }
 
@@ -472,13 +584,14 @@
       align-items: center;
       justify-content: center;
       padding: var(--space-xl);
+      backdrop-filter: blur(6px);
     }
     .lightbox.active { display: flex; }
     .lightbox-img {
       max-width: 90vw;
       max-height: 85vh;
-      border-radius: var(--radius-lg);
-      box-shadow: var(--shadow-lg);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow-xl);
       object-fit: contain;
     }
     .lightbox-close {
@@ -488,10 +601,10 @@
       background: var(--surface);
       border: 1px solid var(--border);
       border-radius: var(--radius-full);
-      width: 40px; height: 40px;
+      width: 36px; height: 36px;
       display: flex; align-items: center; justify-content: center;
       cursor: pointer;
-      font-size: 1.2rem;
+      font-size: 0.95rem;
       color: var(--text);
       transition: all var(--transition);
     }
@@ -501,47 +614,43 @@
        LIVE DEMO
        ============================================================ */
     .demo-wrapper {
-      background: var(--bg-secondary);
       border: 1px solid var(--border);
-      border-radius: var(--radius-xl);
+      border-radius: var(--radius-lg);
       overflow: hidden;
+      box-shadow: var(--shadow);
     }
     .demo-header {
-      background: var(--surface);
+      background: var(--bg-tertiary);
       border-bottom: 1px solid var(--border);
-      padding: 0.75rem var(--space-lg);
+      padding: 0.55rem var(--space-lg);
       display: flex;
       align-items: center;
-      gap: var(--space-sm);
+      gap: 0.45rem;
     }
-    .demo-dot {
-      width: 12px; height: 12px;
-      border-radius: 50%;
-    }
+    .demo-dot { width: 10px; height: 10px; border-radius: 50%; }
     .demo-title {
-      font-size: 0.85rem;
-      color: var(--text-secondary);
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
+      color: var(--text-muted);
       margin-left: auto;
       margin-right: auto;
+      letter-spacing: 0.07em;
+      text-transform: lowercase;
     }
     .demo-body {
       display: grid;
       grid-template-columns: 1fr 1fr;
-      min-height: 320px;
+      min-height: 300px;
     }
-    .demo-panel {
-      display: flex;
-      flex-direction: column;
-    }
-    .demo-panel + .demo-panel {
-      border-left: 1px solid var(--border);
-    }
+    .demo-panel { display: flex; flex-direction: column; }
+    .demo-panel + .demo-panel { border-left: 1px solid var(--border); }
     .demo-panel-label {
-      padding: 0.5rem var(--space-lg);
-      font-size: 0.75rem;
-      font-weight: 600;
+      padding: 0.42rem var(--space-lg);
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
+      font-weight: 500;
       text-transform: uppercase;
-      letter-spacing: 0.1em;
+      letter-spacing: 0.12em;
       color: var(--text-muted);
       border-bottom: 1px solid var(--border-muted);
       background: var(--bg-secondary);
@@ -553,31 +662,35 @@
       background: transparent;
       color: var(--text);
       font-family: var(--font-mono);
-      font-size: 0.85rem;
+      font-size: 0.83rem;
       padding: var(--space-lg);
       resize: none;
-      line-height: 1.6;
+      line-height: 1.65;
     }
     .demo-output {
       flex: 1;
       padding: var(--space-lg);
       font-family: var(--font-mono);
-      font-size: 0.85rem;
+      font-size: 0.83rem;
       color: var(--text-secondary);
       overflow-y: auto;
       white-space: pre-wrap;
       word-break: break-all;
-      line-height: 1.6;
+      line-height: 1.65;
+      background: var(--bg-secondary);
+      border: none;
     }
     .demo-footer {
-      padding: 0.75rem var(--space-lg);
+      padding: 0.55rem var(--space-lg);
       display: flex;
       align-items: center;
       justify-content: space-between;
       border-top: 1px solid var(--border);
-      background: var(--surface);
-      font-size: 0.8rem;
+      background: var(--bg-tertiary);
+      font-family: var(--font-mono);
+      font-size: 0.67rem;
       color: var(--text-muted);
+      letter-spacing: 0.04em;
     }
     .demo-preset-btns {
       display: flex;
@@ -586,87 +699,87 @@
       margin-bottom: var(--space-md);
     }
     .demo-preset-btn {
-      background: var(--bg-secondary);
+      background: var(--surface);
       border: 1px solid var(--border);
-      border-radius: var(--radius-full);
-      padding: 0.25rem 0.75rem;
-      font-size: 0.8rem;
+      border-radius: var(--radius-sm);
+      padding: 0.28rem 0.75rem;
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
       color: var(--text-secondary);
       cursor: pointer;
       transition: all var(--transition);
-      font-family: var(--font);
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
     }
-    .demo-preset-btn:hover { background: var(--surface-hover); color: var(--text); border-color: var(--accent); }
-    .demo-preset-btn.active { background: var(--gradient-subtle); color: var(--accent); border-color: var(--accent); }
+    .demo-preset-btn:hover { background: var(--bg-secondary); color: var(--text); border-color: var(--text-muted); }
+    .demo-preset-btn.active { background: var(--accent-subtle); color: var(--accent); border-color: var(--accent); }
 
     /* ============================================================
        ALERT TYPES
        ============================================================ */
     .alerts-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
       gap: var(--space-md);
     }
     .alert-card {
       border-radius: var(--radius-md);
       padding: var(--space-md) var(--space-lg);
-      border-left: 4px solid;
-      cursor: default;
+      border-left: 3px solid;
       transition: transform var(--transition), box-shadow var(--transition);
     }
     .alert-card:hover { transform: translateY(-2px); box-shadow: var(--shadow); }
     .alert-card-header {
       display: flex;
       align-items: center;
-      gap: var(--space-sm);
+      gap: 0.35rem;
       font-weight: 700;
-      font-size: 0.875rem;
+      font-size: 0.78rem;
       margin-bottom: var(--space-xs);
+      letter-spacing: 0.05em;
     }
     .alert-card-syntax {
       font-family: var(--font-mono);
-      font-size: 0.75rem;
-      opacity: 0.7;
+      font-size: 0.68rem;
+      opacity: 0.6;
       margin-bottom: var(--space-sm);
     }
     .alert-card-desc {
-      font-size: 0.8rem;
-      opacity: 0.85;
-      line-height: 1.4;
+      font-size: 0.77rem;
+      opacity: 0.8;
+      line-height: 1.45;
     }
 
     /* ============================================================
-       SYNTAX REFERENCE TABLE
+       SYNTAX TABLE
        ============================================================ */
     .syntax-table-wrapper {
       overflow-x: auto;
       border: 1px solid var(--border);
       border-radius: var(--radius-lg);
     }
-    .syntax-table {
-      width: 100%;
-      border-collapse: collapse;
-      font-size: 0.9rem;
-    }
+    .syntax-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
     .syntax-table th {
       background: var(--bg-secondary);
-      padding: 0.75rem 1.25rem;
+      padding: 0.7rem 1.25rem;
       text-align: left;
-      font-size: 0.8rem;
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
       text-transform: uppercase;
-      letter-spacing: 0.08em;
+      letter-spacing: 0.12em;
       color: var(--text-muted);
       border-bottom: 1px solid var(--border);
+      font-weight: 500;
     }
     .syntax-table td {
-      padding: 0.75rem 1.25rem;
+      padding: 0.65rem 1.25rem;
       border-bottom: 1px solid var(--border-muted);
       color: var(--text-secondary);
     }
     .syntax-table tr:last-child td { border-bottom: none; }
     .syntax-table tr:hover td { background: var(--bg-secondary); }
     .syntax-table td:first-child { color: var(--text); font-weight: 500; }
-    .syntax-table td:nth-child(2) code { color: var(--accent-purple); }
+    .syntax-table td:nth-child(2) code { color: var(--accent); }
 
     /* ============================================================
        ADVANCED FEATURES
@@ -678,12 +791,38 @@
       align-items: center;
       padding: var(--space-2xl) 0;
     }
-    .advanced-feature + .advanced-feature {
-      border-top: 1px solid var(--border-muted);
-    }
+    .advanced-feature + .advanced-feature { border-top: 1px solid var(--border-muted); }
     .advanced-feature.reverse { direction: rtl; }
     .advanced-feature.reverse > * { direction: ltr; }
-    .advanced-feature-content { }
+
+    .advanced-feature-title {
+      font-family: var(--font-display);
+      font-size: 1.7rem;
+      font-weight: 400;
+      margin-bottom: var(--space-md);
+      line-height: 1.2;
+      letter-spacing: -0.01em;
+    }
+    .advanced-feature-desc {
+      color: var(--text-secondary);
+      line-height: 1.75;
+      margin-bottom: var(--space-lg);
+      font-size: 0.95rem;
+    }
+    .feature-list { list-style: none; display: flex; flex-direction: column; gap: var(--space-sm); }
+    .feature-list li {
+      display: flex;
+      align-items: flex-start;
+      gap: var(--space-sm);
+      font-size: 0.875rem;
+      color: var(--text-secondary);
+    }
+    .feature-list li::before {
+      content: '→';
+      color: var(--accent);
+      flex-shrink: 0;
+      margin-top: 1px;
+    }
     .advanced-feature-visual {
       background: var(--bg-secondary);
       border: 1px solid var(--border);
@@ -691,60 +830,40 @@
       padding: var(--space-xl);
       font-size: 0.875rem;
     }
-    .advanced-feature-title {
-      font-size: 1.5rem;
-      font-weight: 700;
-      margin-bottom: var(--space-md);
-    }
-    .advanced-feature-desc {
-      color: var(--text-secondary);
-      line-height: 1.7;
-      margin-bottom: var(--space-lg);
-    }
-    .feature-list {
-      list-style: none;
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-sm);
-    }
-    .feature-list li {
-      display: flex;
-      align-items: flex-start;
-      gap: var(--space-sm);
-      font-size: 0.9rem;
-      color: var(--text-secondary);
-    }
-    .feature-list li::before {
-      content: '✓';
-      color: var(--accent-teal);
-      font-weight: 700;
-      flex-shrink: 0;
-      margin-top: 1px;
-    }
 
-    /* Mock UI components */
+    /* Mock UI */
+    .mock-visual-label {
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
+      color: var(--text-muted);
+      margin-bottom: var(--space-sm);
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
     .mock-toolbar {
       display: flex;
       align-items: center;
       gap: 4px;
-      padding: 6px 8px;
+      padding: 5px 8px;
       background: var(--bg);
       border: 1px solid var(--border);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-sm);
       width: fit-content;
+      flex-wrap: wrap;
     }
     .mock-btn {
       background: var(--surface);
       border: 1px solid var(--border);
       border-radius: var(--radius-sm);
-      padding: 4px 8px;
-      font-size: 0.75rem;
+      padding: 3px 8px;
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
       color: var(--text-secondary);
       cursor: default;
       white-space: nowrap;
     }
-    .mock-btn.active { background: var(--gradient-subtle); border-color: var(--accent); color: var(--accent); }
+    .mock-btn.active { background: var(--accent-subtle); border-color: var(--accent); color: var(--accent); }
     .mock-textarea {
       width: 100%;
       background: var(--bg);
@@ -752,39 +871,35 @@
       border-radius: var(--radius-md);
       padding: var(--space-md);
       font-family: var(--font-mono);
-      font-size: 0.8rem;
+      font-size: 0.77rem;
       color: var(--text-secondary);
       min-height: 80px;
       resize: none;
     }
-
     .mock-alert-row {
       display: flex;
       align-items: center;
       gap: var(--space-sm);
-      padding: var(--space-sm);
-      border-radius: var(--radius-md);
-      font-size: 0.8rem;
+      padding: 0.45rem var(--space-sm);
+      border-radius: var(--radius-sm);
+      font-size: 0.77rem;
       margin-bottom: var(--space-xs);
     }
-    .mock-preview-panes {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: var(--space-sm);
-    }
+    .mock-preview-panes { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-sm); }
     .mock-pane {
       background: var(--bg);
       border: 1px solid var(--border);
-      border-radius: var(--radius-md);
+      border-radius: var(--radius-sm);
       padding: var(--space-sm);
-      font-size: 0.75rem;
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
       color: var(--text-muted);
       min-height: 80px;
     }
     .mock-pane-label {
-      font-size: 0.65rem;
+      font-size: 0.6rem;
       text-transform: uppercase;
-      letter-spacing: 0.08em;
+      letter-spacing: 0.1em;
       color: var(--text-muted);
       margin-bottom: var(--space-xs);
     }
@@ -794,141 +909,120 @@
       justify-content: space-between;
       padding: var(--space-sm);
       border: 1px solid var(--border-muted);
-      border-radius: var(--radius-md);
+      border-radius: var(--radius-sm);
       margin-bottom: var(--space-xs);
-      font-size: 0.8rem;
+      font-size: 0.77rem;
       color: var(--text-secondary);
     }
     .mock-snippet-actions { display: flex; gap: 4px; }
     .mock-mini-btn {
       background: var(--surface);
       border: 1px solid var(--border);
-      border-radius: var(--radius-sm);
+      border-radius: 2px;
       padding: 2px 6px;
-      font-size: 0.7rem;
+      font-family: var(--font-mono);
+      font-size: 0.62rem;
       color: var(--text-muted);
       cursor: default;
     }
 
     /* ============================================================
-       HOW TO USE / STEPS
+       GET STARTED / STEPS
        ============================================================ */
-    .steps {
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-lg);
-    }
-    .step {
-      display: flex;
-      gap: var(--space-lg);
-      align-items: flex-start;
-    }
+    .steps { display: flex; flex-direction: column; gap: var(--space-lg); }
+    .step { display: flex; gap: var(--space-lg); align-items: flex-start; }
     .step-num {
       flex-shrink: 0;
-      width: 36px; height: 36px;
-      background: var(--gradient);
-      border-radius: 50%;
+      width: 30px; height: 30px;
+      background: var(--accent);
+      border-radius: var(--radius-sm);
       display: flex; align-items: center; justify-content: center;
-      font-weight: 800;
-      font-size: 0.875rem;
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      font-weight: 500;
       color: #fff;
     }
-    .step-content { padding-top: 6px; }
-    .step-title { font-weight: 700; margin-bottom: var(--space-xs); }
-    .step-desc { font-size: 0.9rem; color: var(--text-secondary); }
+    .step-content { padding-top: 3px; }
+    .step-title { font-weight: 600; margin-bottom: var(--space-xs); font-size: 0.93rem; }
+    .step-desc { font-size: 0.875rem; color: var(--text-secondary); line-height: 1.65; }
+
+    .install-cta {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-xl);
+      padding: var(--space-xl);
+      text-align: center;
+    }
+    .install-cta-icon { font-size: 2rem; display: block; margin-bottom: var(--space-sm); }
+    .install-cta-title {
+      font-family: var(--font-display);
+      font-size: 1.4rem;
+      font-weight: 400;
+      margin-bottom: var(--space-sm);
+    }
+    .install-cta-sub { font-size: 0.875rem; color: var(--text-secondary); margin-bottom: var(--space-lg); }
 
     /* ============================================================
        PRIVACY
        ============================================================ */
-    .privacy-grid {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: var(--space-lg);
-    }
+    .privacy-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: var(--space-lg); }
     .privacy-card {
-      background: var(--bg-secondary);
+      background: var(--surface);
       border: 1px solid var(--border);
-      border-radius: var(--radius-lg);
+      border-radius: var(--radius-md);
       padding: var(--space-xl);
-      text-align: center;
     }
-    .privacy-icon { font-size: 2.5rem; margin-bottom: var(--space-md); display: block; }
-    .privacy-title { font-weight: 700; margin-bottom: var(--space-sm); }
-    .privacy-desc { font-size: 0.875rem; color: var(--text-secondary); line-height: 1.6; }
+    .privacy-icon { font-size: 1.65rem; margin-bottom: var(--space-md); display: block; }
+    .privacy-title { font-weight: 600; margin-bottom: var(--space-sm); font-size: 0.93rem; }
+    .privacy-desc { font-size: 0.85rem; color: var(--text-secondary); line-height: 1.65; }
 
     /* ============================================================
        FAQ ACCORDION
        ============================================================ */
-    .faq-list { display: flex; flex-direction: column; gap: var(--space-sm); }
-    .faq-item {
-      background: var(--bg-secondary);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-lg);
-      overflow: hidden;
-    }
+    .faq-list { display: flex; flex-direction: column; }
+    .faq-item { border-bottom: 1px solid var(--border-muted); }
+    .faq-item:first-child { border-top: 1px solid var(--border-muted); }
     .faq-question {
       width: 100%;
       background: none;
       border: none;
-      padding: var(--space-lg) var(--space-xl);
+      padding: var(--space-lg) 0;
       text-align: left;
-      font-family: var(--font);
-      font-size: 1rem;
-      font-weight: 600;
+      font-family: var(--font-body);
+      font-size: 0.93rem;
+      font-weight: 500;
       color: var(--text);
       cursor: pointer;
       display: flex;
       justify-content: space-between;
       align-items: center;
       gap: var(--space-md);
-      transition: background var(--transition);
+      transition: color var(--transition);
     }
-    .faq-question:hover { background: var(--surface-hover); }
+    .faq-question:hover { color: var(--accent); }
     .faq-question .faq-icon {
       flex-shrink: 0;
-      font-size: 0.9rem;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
       color: var(--text-muted);
       transition: transform var(--transition);
     }
     .faq-item.open .faq-icon { transform: rotate(180deg); }
-    .faq-answer {
-      max-height: 0;
-      overflow: hidden;
-      transition: max-height 0.3s ease;
-    }
+    .faq-answer { max-height: 0; overflow: hidden; transition: max-height 0.3s ease; }
     .faq-item.open .faq-answer { max-height: 400px; }
     .faq-answer-inner {
-      padding: 0 var(--space-xl) var(--space-lg);
-      font-size: 0.9rem;
-      color: var(--text-secondary);
-      line-height: 1.7;
-      border-top: 1px solid var(--border-muted);
-      padding-top: var(--space-md);
-    }
-
-    /* ============================================================
-       PLACEHOLDER / TODO CALLOUT
-       ============================================================ */
-    .todo-callout {
-      background: rgba(240, 136, 62, 0.1);
-      border: 1px dashed var(--accent-orange);
-      border-radius: var(--radius-md);
-      padding: var(--space-md) var(--space-lg);
+      padding: 0 0 var(--space-lg);
       font-size: 0.875rem;
-      color: var(--accent-orange);
-      margin: var(--space-md) 0;
-      display: flex;
-      gap: var(--space-sm);
-      align-items: flex-start;
+      color: var(--text-secondary);
+      line-height: 1.75;
     }
-    .todo-callout::before { content: '📋'; flex-shrink: 0; }
 
     /* ============================================================
        FOOTER
        ============================================================ */
     .footer {
-      border-top: 1px solid var(--border);
-      padding: var(--space-2xl) 0;
+      border-top: 1px solid var(--border-muted);
+      padding: var(--space-2xl) 0 var(--space-xl);
       margin-top: var(--space-3xl);
     }
     .footer-inner {
@@ -937,34 +1031,53 @@
       gap: var(--space-2xl);
       margin-bottom: var(--space-xl);
     }
-    .footer-brand-name {
-      font-weight: 700;
-      margin-bottom: var(--space-sm);
+    .footer-brand-logo {
       display: flex;
-      flex-direction: column;
-      align-items: flex-start;
+      align-items: center;
       gap: var(--space-sm);
+      margin-bottom: var(--space-md);
     }
-    .footer-brand-name img { width: 64px; height: 64px; border-radius: var(--radius-sm); }
-    .footer-brand-desc { font-size: 0.875rem; color: var(--text-secondary); line-height: 1.6; }
+    .footer-brand-logo img { width: 32px; height: 32px; border-radius: var(--radius-sm); }
+    .footer-brand-logo-text {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      font-weight: 500;
+      color: var(--text);
+    }
+    .footer-brand-logo-arrow { color: var(--accent); }
+    .footer-brand-desc { font-size: 0.875rem; color: var(--text-secondary); line-height: 1.65; margin-bottom: var(--space-md); }
+    .footer-social { display: flex; gap: var(--space-md); flex-wrap: wrap; }
+    .footer-social a {
+      color: var(--text-muted);
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      display: flex;
+      align-items: center;
+      gap: 0.3rem;
+      transition: color var(--transition);
+      text-decoration: none;
+    }
+    .footer-social a:hover { color: var(--text); text-decoration: none; }
     .footer-col-title {
-      font-size: 0.8rem;
-      font-weight: 700;
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
+      font-weight: 500;
       text-transform: uppercase;
-      letter-spacing: 0.1em;
+      letter-spacing: 0.14em;
       color: var(--text-muted);
       margin-bottom: var(--space-md);
     }
     .footer-links { list-style: none; display: flex; flex-direction: column; gap: var(--space-sm); }
-    .footer-links a { font-size: 0.875rem; color: var(--text-secondary); }
-    .footer-links a:hover { color: var(--text); }
+    .footer-links a { font-size: 0.875rem; color: var(--text-secondary); transition: color var(--transition); }
+    .footer-links a:hover { color: var(--text); text-decoration: none; }
     .footer-bottom {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding-top: var(--space-xl);
+      padding-top: var(--space-lg);
       border-top: 1px solid var(--border-muted);
-      font-size: 0.8rem;
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
       color: var(--text-muted);
       flex-wrap: wrap;
       gap: var(--space-md);
@@ -972,23 +1085,42 @@
     .version-badge {
       background: var(--bg-secondary);
       border: 1px solid var(--border);
-      border-radius: var(--radius-full);
-      padding: 0.2rem 0.6rem;
-      font-size: 0.75rem;
+      border-radius: 2px;
+      padding: 0.12rem 0.45rem;
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
       color: var(--text-muted);
+      letter-spacing: 0.07em;
     }
+
+    /* ============================================================
+       CALLOUT
+       ============================================================ */
+    .callout {
+      border-left: 3px solid var(--accent);
+      background: var(--accent-subtle);
+      border-radius: 0 var(--radius-md) var(--radius-md) 0;
+      padding: var(--space-md) var(--space-lg);
+      font-size: 0.875rem;
+      color: var(--text-secondary);
+    }
+    .callout strong { color: var(--text); }
 
     /* ============================================================
        RESPONSIVE
        ============================================================ */
-    @media (max-width: 900px) {
-      .grid-3 { grid-template-columns: repeat(2, 1fr); }
-      .grid-4 { grid-template-columns: repeat(2, 1fr); }
-      .screenshots-grid { grid-template-columns: repeat(2, 1fr); }
+    @media (max-width: 960px) {
+      .features-grid { grid-template-columns: repeat(2,1fr); }
+      .features-grid .feature-card:nth-child(3n)        { border-right: 1px solid var(--border); }
+      .features-grid .feature-card:nth-last-child(-n+3)  { border-bottom: 1px solid var(--border); }
+      .features-grid .feature-card:nth-child(2n)         { border-right: none; }
+      .features-grid .feature-card:nth-last-child(-n+2)  { border-bottom: none; }
+      .screenshots-grid { grid-template-columns: repeat(2,1fr); }
       .advanced-feature { grid-template-columns: 1fr; gap: var(--space-xl); }
       .advanced-feature.reverse { direction: ltr; }
       .footer-inner { grid-template-columns: 1fr 1fr; }
       .privacy-grid { grid-template-columns: 1fr 1fr; }
+      .grid-3 { grid-template-columns: repeat(2,1fr); }
     }
 
     @media (max-width: 640px) {
@@ -998,7 +1130,7 @@
         display: flex;
         flex-direction: column;
         position: fixed;
-        top: 60px; left: 0; right: 0;
+        top: 56px; left: 0; right: 0;
         background: var(--bg);
         border-bottom: 1px solid var(--border);
         padding: var(--space-lg) var(--space-xl);
@@ -1007,15 +1139,16 @@
       }
       .hamburger { display: flex; }
       .grid-2 { grid-template-columns: 1fr; }
-      .grid-3 { grid-template-columns: 1fr; }
-      .grid-4 { grid-template-columns: 1fr 1fr; }
+      .features-grid { grid-template-columns: 1fr; }
+      .features-grid .feature-card { border-right: none !important; border-bottom: 1px solid var(--border) !important; }
+      .features-grid .feature-card:last-child { border-bottom: none !important; }
       .screenshots-grid { grid-template-columns: 1fr; }
       .privacy-grid { grid-template-columns: 1fr; }
       .demo-body { grid-template-columns: 1fr; }
       .demo-panel + .demo-panel { border-left: none; border-top: 1px solid var(--border); }
       .footer-inner { grid-template-columns: 1fr; gap: var(--space-xl); }
       .footer-bottom { flex-direction: column; align-items: flex-start; }
-      .hero-stats { gap: var(--space-xl); }
+      .hero-stats { max-width: 100%; flex-wrap: wrap; }
       .mock-preview-panes { grid-template-columns: 1fr; }
     }
 
@@ -1034,11 +1167,11 @@
     <div class="nav-inner">
       <a href="#" class="nav-logo">
         <img src="icons/Icon128.png" alt="Extension icon" />
-        MD → SN
+        <span class="nav-logo-text">md<span class="nav-logo-arrow"> → </span>sn</span>
       </a>
       <ul class="nav-links" id="navLinks">
         <li><a href="#features">Features</a></li>
-        <li><a href="#demo">Live Demo</a></li>
+        <li><a href="#demo">Demo</a></li>
         <li><a href="#alerts">Alerts</a></li>
         <li><a href="#syntax">Syntax</a></li>
         <li><a href="#how-to-use">Get Started</a></li>
@@ -1046,10 +1179,7 @@
       </ul>
       <div class="nav-actions">
         <button class="btn btn-ghost theme-toggle" id="themeToggle" aria-label="Toggle theme" title="Toggle dark/light mode">🌙</button>
-        <!-- TODO(user): Replace href with actual Chrome Web Store URL after publishing -->
-        <a href="#install" class="btn btn-primary" id="navCta">
-          ⬇ Install Free
-        </a>
+        <a href="#install" class="btn btn-primary" id="navCta">Install Free</a>
         <button class="btn btn-ghost hamburger" id="hamburger" aria-label="Menu">
           <span></span><span></span><span></span>
         </button>
@@ -1062,56 +1192,53 @@
      HERO
      ================================================================ -->
 <section class="hero" id="hero">
+  <div class="hero-glow"></div>
   <div class="container">
-    <div class="hero-badge">
-      <span class="hero-badge-dot"></span>
-      Version 3.0.0 · Free Chrome Extension
-    </div>
-    <img src="icons/Icon.svg" alt="Markdown to ServiceNow icon" class="hero-icon" />
-    <h1 class="hero-title">
-      Write Markdown,<br/>
-      <span class="gradient-text">Post to ServiceNow</span>
-    </h1>
-    <p class="hero-subtitle">
-      A Chrome extension that converts Markdown to ServiceNow journal format instantly —
-      with a popup converter, right-click context menu, and in-page toolbar on every journal field.
-    </p>
-    <div class="hero-actions">
-      <!-- TODO(user): Replace with actual Chrome Web Store URL after publishing -->
-      <a href="#install" class="btn btn-primary btn-lg" id="heroInstallBtn">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="4"/><line x1="21.17" y1="8" x2="12" y2="8"/><line x1="3.95" y1="6.06" x2="8.54" y2="14"/><line x1="10.88" y1="21.94" x2="15.46" y2="14"/></svg>
-        Add to Chrome — It's Free
-      </a>
-      <a href="https://github.com/yadav-prakhar/markdown-sn-extension" target="_blank" rel="noopener" class="btn btn-secondary btn-lg">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-        View on GitHub
-      </a>
-    </div>
-    <div class="hero-shortcut">
-      <span>Open popup with</span>
-      <kbd class="kbd">⌘</kbd><kbd class="kbd">Shift</kbd><kbd class="kbd">M</kbd>
-      <span>on Mac or</span>
-      <kbd class="kbd">Ctrl</kbd><kbd class="kbd">Shift</kbd><kbd class="kbd">M</kbd>
-      <span>on Windows</span>
-    </div>
-    <div class="hero-stats">
-      <div class="hero-stat">
-        <div class="hero-stat-value">3</div>
-        <div class="hero-stat-label">Conversion Methods</div>
+    <div class="hero-inner">
+      <div class="hero-badge">
+        <span class="hero-badge-dot"></span>
+        Version 3.0.0 &middot; Free Chrome Extension
       </div>
-      <div class="hero-stat">
-        <div class="hero-stat-value">10+</div>
-        <div class="hero-stat-label">Alert Types</div>
+      <img src="icons/Icon.svg" alt="Markdown to ServiceNow icon" class="hero-icon" />
+      <h1 class="hero-title">
+        Write Markdown.<br>
+        <span class="hero-title-accent">Post to ServiceNow.</span>
+      </h1>
+      <p class="hero-subtitle">
+        A Chrome extension that converts Markdown to ServiceNow journal format instantly —
+        with a popup converter, right-click context menu, and in-page toolbar on every journal field.
+      </p>
+      <div class="hero-actions">
+        <a href="#install" class="btn btn-primary btn-lg" id="heroInstallBtn">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="4"/><line x1="21.17" y1="8" x2="12" y2="8"/><line x1="3.95" y1="6.06" x2="8.54" y2="14"/><line x1="10.88" y1="21.94" x2="15.46" y2="14"/></svg>
+          Add to Chrome — It's Free
+        </a>
+        <a href="https://github.com/yadav-prakhar/markdown-sn-extension" target="_blank" rel="noopener" class="btn btn-secondary btn-lg">
+          <svg width="15" height="15" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          View on GitHub
+        </a>
       </div>
-      <div class="hero-stat">
-        <div class="hero-stat-value">No</div>
-        <div class="hero-stat-label">Data Collected</div>
+      <div class="hero-shortcut">
+        <span>Open popup with</span>
+        <kbd class="kbd">⌘</kbd> <kbd class="kbd">Shift</kbd> <kbd class="kbd">M</kbd>
+        <span>on Mac or</span>
+        <kbd class="kbd">Ctrl</kbd> <kbd class="kbd">Shift</kbd> <kbd class="kbd">M</kbd>
+        <span>on Windows</span>
       </div>
-      <!-- TODO(user): Update install count once published to Chrome Web Store -->
-      <!-- <div class="hero-stat">
-        <div class="hero-stat-value" id="installCount">—</div>
-        <div class="hero-stat-label">Active Users</div>
-      </div> -->
+      <div class="hero-stats">
+        <div class="hero-stat">
+          <div class="hero-stat-value">3</div>
+          <div class="hero-stat-label">Conversion Methods</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-value">10+</div>
+          <div class="hero-stat-label">Alert Types</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-value">Zero</div>
+          <div class="hero-stat-label">Data Collected</div>
+        </div>
+      </div>
     </div>
   </div>
 </section>
@@ -1121,55 +1248,67 @@
      ================================================================ -->
 <section class="section" id="features">
   <div class="container">
-    <div class="section-label">Features</div>
-    <h2 class="section-title">Everything you need for ServiceNow</h2>
+    <div class="section-eyebrow">
+      <span class="section-tag">Features</span>
+      <div class="section-tag-line"></div>
+    </div>
+    <h2 class="section-title">Everything you need<br>for <em>ServiceNow</em></h2>
     <p class="section-subtitle">Three ways to convert, with powerful extras for power users.</p>
-    <div class="grid-3">
+    <div class="features-grid">
       <div class="feature-card">
+        <span class="feature-num">01</span>
         <span class="feature-icon">📝</span>
         <div class="feature-title">Popup Converter</div>
         <div class="feature-desc">Click the extension icon to open a full converter. Paste Markdown, see the ServiceNow output instantly, and copy with one click.</div>
       </div>
       <div class="feature-card">
+        <span class="feature-num">02</span>
         <span class="feature-icon">🖱️</span>
         <div class="feature-title">Context Menu</div>
         <div class="feature-desc">Select any Markdown text on a page, right-click, and choose "Convert Markdown to ServiceNow" — it copies to clipboard automatically.</div>
       </div>
       <div class="feature-card">
+        <span class="feature-num">03</span>
         <span class="feature-icon">⚡</span>
         <div class="feature-title">In-Page Toolbar</div>
         <div class="feature-desc">A floating toolbar appears on every ServiceNow journal field. Convert in-place, preview before applying, and restore if needed.</div>
       </div>
       <div class="feature-card">
+        <span class="feature-num">04</span>
         <span class="feature-icon">👁</span>
         <div class="feature-title">Live Preview</div>
         <div class="feature-desc">Side-by-side preview modal shows how your Markdown will render before committing the change to the field.</div>
-        <span class="feature-tag">v3.0.0 New</span>
+        <span class="feature-tag">v3.0 New</span>
       </div>
       <div class="feature-card">
+        <span class="feature-num">05</span>
         <span class="feature-icon">🎨</span>
         <div class="feature-title">Custom Alerts</div>
         <div class="feature-desc">Create your own alert types with custom emojis, colors, and names. Import/export your config to share with teammates.</div>
       </div>
       <div class="feature-card">
+        <span class="feature-num">06</span>
         <span class="feature-icon">📌</span>
         <div class="feature-title">Snippets Manager</div>
         <div class="feature-desc">Save reusable Markdown blocks and insert them with a click. Great for standard response templates and boilerplate.</div>
-        <span class="feature-tag">v3.0.0 New</span>
+        <span class="feature-tag">v3.0 New</span>
       </div>
       <div class="feature-card">
+        <span class="feature-num">07</span>
         <span class="feature-icon">↩️</span>
         <div class="feature-title">Undo / Restore</div>
         <div class="feature-desc">After converting, a restore button appears per field. Changed your mind? One click reverts to the original Markdown.</div>
-        <span class="feature-tag">v3.0.0 New</span>
+        <span class="feature-tag">v3.0 New</span>
       </div>
       <div class="feature-card">
+        <span class="feature-num">08</span>
         <span class="feature-icon">?</span>
         <div class="feature-title">Cheatsheet</div>
         <div class="feature-desc">Built-in Markdown syntax reference, accessible from the toolbar. Click any item to insert the syntax at your cursor.</div>
-        <span class="feature-tag">v3.0.0 New</span>
+        <span class="feature-tag">v3.0 New</span>
       </div>
       <div class="feature-card">
+        <span class="feature-num">09</span>
         <span class="feature-icon">🔒</span>
         <div class="feature-title">100% Private</div>
         <div class="feature-desc">No data is ever collected, transmitted, or stored externally. Everything runs locally in your browser. Fully open source.</div>
@@ -1183,33 +1322,36 @@
      ================================================================ -->
 <section class="section" id="screenshots">
   <div class="container">
-    <div class="section-label">Screenshots</div>
-    <h2 class="section-title">See it in action</h2>
+    <div class="section-eyebrow">
+      <span class="section-tag">Screenshots</span>
+      <div class="section-tag-line"></div>
+    </div>
+    <h2 class="section-title">See it <em>in action</em></h2>
     <p class="section-subtitle">Click any screenshot to enlarge.</p>
     <div class="screenshots-grid">
       <div class="screenshot-card" onclick="openLightbox('screenshots/ss-popup.png', 'Popup Converter Interface')">
         <img src="screenshots/ss-popup.png" alt="Popup converter interface" loading="lazy" />
-        <div class="screenshot-caption">📝 Popup Converter</div>
+        <div class="screenshot-caption">Popup Converter</div>
       </div>
       <div class="screenshot-card" onclick="openLightbox('screenshots/ss2.png', 'Markdown Conversion Example')">
         <img src="screenshots/ss2.png" alt="Markdown conversion example" loading="lazy" />
-        <div class="screenshot-caption">⚡ Conversion in Action</div>
+        <div class="screenshot-caption">Conversion in Action</div>
       </div>
       <div class="screenshot-card" onclick="openLightbox('screenshots/ssAlerts.png', 'Alert Types Showcase')">
         <img src="screenshots/ssAlerts.png" alt="Alert types showcase" loading="lazy" />
-        <div class="screenshot-caption">🎨 Alert Types</div>
+        <div class="screenshot-caption">Alert Types</div>
       </div>
       <div class="screenshot-card" onclick="openLightbox('screenshots/ss-toolbar.png', 'In-Page Toolbar on ServiceNow')">
         <img src="screenshots/ss-toolbar.png" alt="In-page toolbar on ServiceNow journal field" loading="lazy" />
-        <div class="screenshot-caption">⚙️ In-Page Toolbar</div>
+        <div class="screenshot-caption">In-Page Toolbar</div>
       </div>
       <div class="screenshot-card" onclick="openLightbox('screenshots/ss-preview.png', 'Preview Modal')">
         <img src="screenshots/ss-preview.png" alt="Preview modal showing rendered output" loading="lazy" />
-        <div class="screenshot-caption">👁️ Preview Modal</div>
+        <div class="screenshot-caption">Preview Modal</div>
       </div>
       <div class="screenshot-card" onclick="openLightbox('screenshots/ss-settings.png', 'Custom Alerts Settings')">
         <img src="screenshots/ss-settings.png" alt="Custom alerts settings panel" loading="lazy" />
-        <div class="screenshot-caption">🛠️ Settings &amp; Custom Alerts</div>
+        <div class="screenshot-caption">Settings &amp; Custom Alerts</div>
       </div>
     </div>
   </div>
@@ -1226,8 +1368,11 @@
      ================================================================ -->
 <section class="section" id="demo">
   <div class="container">
-    <div class="section-label">Live Demo</div>
-    <h2 class="section-title">Try it right here</h2>
+    <div class="section-eyebrow">
+      <span class="section-tag">Live Demo</span>
+      <div class="section-tag-line"></div>
+    </div>
+    <h2 class="section-title">Try it <em>right here</em></h2>
     <p class="section-subtitle">Type Markdown in the left panel and see the ServiceNow journal output on the right — powered by the actual conversion library.</p>
 
     <div class="demo-preset-btns">
@@ -1243,11 +1388,11 @@
         <span class="demo-dot" style="background:#ff5f57"></span>
         <span class="demo-dot" style="background:#ffbd2e"></span>
         <span class="demo-dot" style="background:#28ca42"></span>
-        <span class="demo-title">Markdown → ServiceNow Journal Format</span>
+        <span class="demo-title">markdown → servicenow journal format</span>
       </div>
       <div class="demo-body">
         <div class="demo-panel">
-          <div class="demo-panel-label">✏️ Markdown Input</div>
+          <div class="demo-panel-label">✏ Markdown Input</div>
           <textarea class="demo-input" id="demoInput" spellcheck="false" aria-label="Markdown input"></textarea>
         </div>
         <div class="demo-panel">
@@ -1256,7 +1401,7 @@
         </div>
       </div>
       <div class="demo-footer">
-        <span id="demoCharCount">0 characters</span>
+        <span id="demoCharCount">0 chars</span>
         <span>Output is the raw ServiceNow journal format (as pasted into a journal field)</span>
       </div>
     </div>
@@ -1268,21 +1413,22 @@
      ================================================================ -->
 <section class="section" id="alerts">
   <div class="container">
-    <div class="section-label">Alert Types</div>
-    <h2 class="section-title">10 built-in alert styles</h2>
+    <div class="section-eyebrow">
+      <span class="section-tag">Alert Types</span>
+      <div class="section-tag-line"></div>
+    </div>
+    <h2 class="section-title">10 built-in <em>alert styles</em></h2>
     <p class="section-subtitle">Use the <code>&gt; [!TYPE]</code> syntax in your Markdown. Each alert renders with a distinct color in ServiceNow.</p>
     <div class="alerts-grid" id="alertsGrid">
       <!-- Populated by JavaScript -->
     </div>
-    <div style="margin-top: var(--space-xl); padding: var(--space-lg); background: var(--bg-secondary); border: 1px solid var(--border); border-radius: var(--radius-lg);">
-      <p style="font-size: 0.875rem; color: var(--text-secondary); margin-bottom: var(--space-sm);">
-        <strong>Example syntax:</strong>
-      </p>
-      <pre><code>&gt; [!WARNING]
+    <div class="callout" style="margin-top: var(--space-xl);">
+      <strong>Example syntax:</strong>
+      <pre style="margin-top: var(--space-sm); background: transparent; border: none; padding: 0; font-size: 0.8rem; color: var(--text-secondary);"><code>&gt; [!WARNING]
 &gt; This deployment will cause a brief service interruption.
 &gt; Estimated downtime: 5 minutes.</code></pre>
     </div>
-    <div style="margin-top: var(--space-lg); padding: var(--space-lg); background: var(--gradient-subtle); border: 1px solid var(--border); border-radius: var(--radius-lg);">
+    <div style="margin-top: var(--space-lg); padding: var(--space-lg); background: var(--bg-secondary); border: 1px solid var(--border); border-radius: var(--radius-lg);">
       <strong style="display: block; margin-bottom: var(--space-sm);">✨ Plus: Unlimited custom alerts</strong>
       <p style="font-size: 0.875rem; color: var(--text-secondary);">Create your own alert types with any name, emoji, and color scheme via the extension settings. Import and export configurations to share with your team.</p>
     </div>
@@ -1294,8 +1440,11 @@
      ================================================================ -->
 <section class="section" id="syntax">
   <div class="container">
-    <div class="section-label">Syntax Reference</div>
-    <h2 class="section-title">Supported Markdown</h2>
+    <div class="section-eyebrow">
+      <span class="section-tag">Syntax Reference</span>
+      <div class="section-tag-line"></div>
+    </div>
+    <h2 class="section-title">Supported <em>Markdown</em></h2>
     <p class="section-subtitle">All standard Markdown elements plus ServiceNow-specific extensions.</p>
     <div class="syntax-table-wrapper">
       <table class="syntax-table">
@@ -1335,8 +1484,11 @@
      ================================================================ -->
 <section class="section" id="advanced">
   <div class="container">
-    <div class="section-label">Advanced Features</div>
-    <h2 class="section-title">Built for power users</h2>
+    <div class="section-eyebrow">
+      <span class="section-tag">Advanced Features</span>
+      <div class="section-tag-line"></div>
+    </div>
+    <h2 class="section-title">Built for <em>power users</em></h2>
 
     <!-- Live Preview -->
     <div class="advanced-feature">
@@ -1353,24 +1505,24 @@
         </ul>
       </div>
       <div class="advanced-feature-visual">
-        <div style="font-size: 0.75rem; color: var(--text-muted); margin-bottom: var(--space-sm);">📝 Preview Modal</div>
+        <div class="mock-visual-label">Preview Modal</div>
         <div class="mock-preview-panes">
           <div class="mock-pane">
             <div class="mock-pane-label">Markdown</div>
-            <div style="color: var(--text-secondary);">## Status Update<br/>Everything is **on track**.<br/>&gt; [!SUCCESS]<br/>&gt; Tests passing.</div>
+            <div style="color: var(--text-secondary); font-family: var(--font-mono); font-size: 0.68rem; line-height: 1.6;">## Status Update<br/>Everything is **on track**.<br/>&gt; [!SUCCESS]<br/>&gt; Tests passing.</div>
           </div>
           <div class="mock-pane">
             <div class="mock-pane-label">Preview</div>
-            <div style="color: var(--text-secondary);">
-              <div style="font-weight:700; font-size:1rem; margin-bottom:4px;">Status Update</div>
-              <div>Everything is <strong>on track</strong>.</div>
-              <div style="background:#e0f2f1; border-left:3px solid #2aa198; padding:4px 8px; margin-top:4px; font-size:0.75rem; border-radius:3px;">✅ SUCCESS: Tests passing.</div>
+            <div style="color: var(--text-secondary); font-size: 0.75rem; line-height: 1.5;">
+              <div style="font-weight:700; font-size:0.85rem; margin-bottom:3px;">Status Update</div>
+              <div style="margin-bottom:4px;">Everything is <strong>on track</strong>.</div>
+              <div style="background:#e0f2f1; border-left:3px solid #2aa198; padding:4px 8px; font-size:0.68rem; border-radius:2px;">✅ Tests passing.</div>
             </div>
           </div>
         </div>
         <div style="display:flex; gap:8px; justify-content:flex-end; margin-top: var(--space-md);">
           <span class="mock-mini-btn">Cancel</span>
-          <span class="mock-mini-btn" style="background: var(--gradient-subtle); border-color: var(--accent); color: var(--accent);">Apply ✓</span>
+          <span class="mock-mini-btn" style="background: var(--accent-subtle); border-color: var(--accent); color: var(--accent);">Apply ✓</span>
         </div>
       </div>
     </div>
@@ -1391,7 +1543,7 @@
         </ul>
       </div>
       <div class="advanced-feature-visual">
-        <div style="font-size: 0.75rem; color: var(--text-muted); margin-bottom: var(--space-sm);">⚙️ Custom Alert Creator</div>
+        <div class="mock-visual-label">Custom Alert Creator</div>
         <div style="display:flex; flex-direction:column; gap: var(--space-xs);">
           <div class="mock-alert-row" style="background:#e0f2f1; border-left:3px solid #2aa198; color:#055f5b;">✅ <strong>SUCCESS</strong> — built-in</div>
           <div class="mock-alert-row" style="background:#faf3d1; border-left:3px solid #d4a72c; color:#7c5e10;">⚠️ <strong>WARNING</strong> — built-in</div>
@@ -1399,7 +1551,7 @@
           <div style="margin-top: var(--space-sm); display:flex; gap:8px; justify-content:flex-end;">
             <span class="mock-mini-btn">📥 Import</span>
             <span class="mock-mini-btn">📤 Export</span>
-            <span class="mock-mini-btn" style="background: var(--gradient-subtle); border-color: var(--accent); color: var(--accent);">+ Add Alert</span>
+            <span class="mock-mini-btn" style="background: var(--accent-subtle); border-color: var(--accent); color: var(--accent);">+ Add Alert</span>
           </div>
         </div>
       </div>
@@ -1421,7 +1573,7 @@
         </ul>
       </div>
       <div class="advanced-feature-visual">
-        <div style="font-size: 0.75rem; color: var(--text-muted); margin-bottom: var(--space-sm);">📌 Saved Snippets</div>
+        <div class="mock-visual-label">Saved Snippets</div>
         <div class="mock-snippet-item">
           <span>🔧 Standard Maintenance Notice</span>
           <div class="mock-snippet-actions">
@@ -1466,7 +1618,7 @@
         </ul>
       </div>
       <div class="advanced-feature-visual">
-        <div style="font-size: 0.75rem; color: var(--text-muted); margin-bottom: var(--space-sm);">⚡ ServiceNow Journal Field</div>
+        <div class="mock-visual-label">ServiceNow Journal Field</div>
         <div class="mock-toolbar">
           <span class="mock-btn active">🔄 Convert</span>
           <span class="mock-btn">👁 Preview</span>
@@ -1490,18 +1642,18 @@ Everything is **on track** for the Thursday release.
      ================================================================ -->
 <section class="section" id="how-to-use">
   <div class="container">
-    <div class="section-label">Get Started</div>
-    <h2 class="section-title">Up and running in 60 seconds</h2>
+    <div class="section-eyebrow">
+      <span class="section-tag">Get Started</span>
+      <div class="section-tag-line"></div>
+    </div>
+    <h2 class="section-title">Up and running<br>in <em>60 seconds</em></h2>
     <div class="grid-2" style="gap: var(--space-3xl); align-items: start;">
       <div class="steps">
         <div class="step">
           <div class="step-num">1</div>
           <div class="step-content">
             <div class="step-title">Install from the Chrome Web Store</div>
-            <div class="step-desc">
-              Click the install button or search "Markdown to ServiceNow" in the Chrome Web Store. No sign-in or account required.
-              <!-- TODO(user): Add direct Chrome Web Store link once published -->
-            </div>
+            <div class="step-desc">Click the install button or search "Markdown to ServiceNow" in the Chrome Web Store. No sign-in or account required.</div>
           </div>
         </div>
         <div class="step">
@@ -1528,42 +1680,42 @@ Everything is **on track** for the Thursday release.
       </div>
       <div>
         <div style="background: var(--bg-secondary); border: 1px solid var(--border); border-radius: var(--radius-xl); padding: var(--space-xl); margin-bottom: var(--space-lg);">
-          <div class="section-label" style="margin-bottom: var(--space-md);">Three ways to convert</div>
+          <div style="font-family: var(--font-mono); font-size: 0.65rem; color: var(--accent); text-transform: uppercase; letter-spacing: 0.14em; margin-bottom: var(--space-md);">Three ways to convert</div>
           <div style="display: flex; flex-direction: column; gap: var(--space-md);">
             <div style="display:flex; gap:var(--space-md); align-items:flex-start;">
-              <span style="font-size:1.5rem;">📝</span>
+              <span style="font-size:1.35rem; line-height:1; padding-top:3px; flex-shrink:0;">📝</span>
               <div>
-                <div style="font-weight:600; margin-bottom:2px;">Popup</div>
-                <div style="font-size:0.875rem; color:var(--text-secondary);">Click icon or press <kbd class="kbd">⌘⇧M</kbd>. Paste markdown, copy output.</div>
+                <div style="font-weight:600; margin-bottom:2px; font-size:0.9rem;">Popup</div>
+                <div style="font-size:0.85rem; color:var(--text-secondary);">Click icon or press <kbd class="kbd">⌘⇧M</kbd>. Paste markdown, copy output.</div>
               </div>
             </div>
             <div style="display:flex; gap:var(--space-md); align-items:flex-start;">
-              <span style="font-size:1.5rem;">🖱️</span>
+              <span style="font-size:1.35rem; line-height:1; padding-top:3px; flex-shrink:0;">🖱️</span>
               <div>
-                <div style="font-weight:600; margin-bottom:2px;">Context Menu</div>
-                <div style="font-size:0.875rem; color:var(--text-secondary);">Select text → right-click → "Convert Markdown to ServiceNow" → auto-copied.</div>
+                <div style="font-weight:600; margin-bottom:2px; font-size:0.9rem;">Context Menu</div>
+                <div style="font-size:0.85rem; color:var(--text-secondary);">Select text → right-click → "Convert Markdown to ServiceNow" → auto-copied.</div>
               </div>
             </div>
             <div style="display:flex; gap:var(--space-md); align-items:flex-start;">
-              <span style="font-size:1.5rem;">⚡</span>
+              <span style="font-size:1.35rem; line-height:1; padding-top:3px; flex-shrink:0;">⚡</span>
               <div>
-                <div style="font-weight:600; margin-bottom:2px;">In-Page Toolbar</div>
-                <div style="font-size:0.875rem; color:var(--text-secondary);">Auto-injected on ServiceNow journal fields. Convert, preview, restore in-place.</div>
+                <div style="font-weight:600; margin-bottom:2px; font-size:0.9rem;">In-Page Toolbar</div>
+                <div style="font-size:0.85rem; color:var(--text-secondary);">Auto-injected on ServiceNow journal fields. Convert, preview, restore in-place.</div>
               </div>
             </div>
           </div>
         </div>
 
         <!-- Install CTA -->
-        <div id="install" style="background: var(--gradient-subtle); border: 1px solid var(--border); border-radius: var(--radius-xl); padding: var(--space-xl); text-align:center;">
-          <div style="font-size:2rem; margin-bottom: var(--space-sm);">🛒</div>
-          <div style="font-weight:700; font-size:1.1rem; margin-bottom:var(--space-sm);">Ready to install?</div>
-          <div style="font-size:0.875rem; color:var(--text-secondary); margin-bottom:var(--space-lg);">Free. No account. No data collection.</div>
+        <div id="install" class="install-cta">
+          <span class="install-cta-icon">🛒</span>
+          <div class="install-cta-title">Ready to install?</div>
+          <div class="install-cta-sub">Free. No account. No data collection.</div>
           <a href="#" class="btn btn-primary btn-lg" style="width:100%; justify-content:center;">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="4"/><line x1="21.17" y1="8" x2="12" y2="8"/><line x1="3.95" y1="6.06" x2="8.54" y2="14"/><line x1="10.88" y1="21.94" x2="15.46" y2="14"/></svg>
-        Add to Chrome — It's Free
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="4"/><line x1="21.17" y1="8" x2="12" y2="8"/><line x1="3.95" y1="6.06" x2="8.54" y2="14"/><line x1="10.88" y1="21.94" x2="15.46" y2="14"/></svg>
+            Add to Chrome — It's Free
           </a>
-          <div style="font-size:0.8rem; color:var(--text-secondary); margin-top:var(--space-sm);">Chrome Web Store listing coming soon</div>
+          <div style="font-family: var(--font-mono); font-size: 0.67rem; color: var(--text-muted); margin-top: var(--space-sm);">Chrome Web Store listing coming soon</div>
         </div>
       </div>
     </div>
@@ -1575,8 +1727,11 @@ Everything is **on track** for the Thursday release.
      ================================================================ -->
 <section class="section" id="privacy">
   <div class="container">
-    <div class="section-label">Privacy & Security</div>
-    <h2 class="section-title">Your data never leaves your browser</h2>
+    <div class="section-eyebrow">
+      <span class="section-tag">Privacy &amp; Security</span>
+      <div class="section-tag-line"></div>
+    </div>
+    <h2 class="section-title">Your data never <em>leaves your browser</em></h2>
     <p class="section-subtitle">Markdown to ServiceNow is 100% local. There are no servers, no accounts, no analytics.</p>
     <div class="privacy-grid">
       <div class="privacy-card">
@@ -1623,8 +1778,11 @@ Everything is **on track** for the Thursday release.
      ================================================================ -->
 <section class="section" id="faq">
   <div class="container">
-    <div class="section-label">FAQ</div>
-    <h2 class="section-title">Frequently asked questions</h2>
+    <div class="section-eyebrow">
+      <span class="section-tag">FAQ</span>
+      <div class="section-tag-line"></div>
+    </div>
+    <h2 class="section-title">Frequently asked <em>questions</em></h2>
     <div class="faq-list" style="max-width: 760px;">
       <div class="faq-item">
         <button class="faq-question" onclick="toggleFaq(this)">
@@ -1695,10 +1853,7 @@ Everything is **on track** for the Thursday release.
           <span class="faq-icon">▾</span>
         </button>
         <div class="faq-answer">
-          <div class="faq-answer-inner">
-            Currently, only Chrome (and Chromium-based browsers like Edge and Brave) are officially supported. Firefox and Safari support is not planned at this time, but contributions are welcome on GitHub.
-            <!-- TODO(user): Update this answer if Firefox/Safari support is added in the future -->
-          </div>
+          <div class="faq-answer-inner">Currently, only Chrome (and Chromium-based browsers like Edge and Brave) are officially supported. Firefox and Safari support is not planned at this time, but contributions are welcome on GitHub.</div>
         </div>
       </div>
     </div>
@@ -1712,28 +1867,32 @@ Everything is **on track** for the Thursday release.
   <div class="container">
     <div class="footer-inner">
       <div>
-        <div class="footer-brand-name">
+        <div class="footer-brand-logo">
           <img src="icons/Icon128.png" alt="Extension icon" />
-          Markdown to ServiceNow
+          <span class="footer-brand-logo-text">md<span class="footer-brand-logo-arrow"> → </span>sn</span>
         </div>
         <div class="footer-brand-desc">
           A Chrome extension for ServiceNow professionals who write in Markdown. Free, open source, and 100% private.
         </div>
-        <div style="margin-top: var(--space-md);">
+        <div style="margin-bottom: var(--space-md);">
           <span class="version-badge">v3.0.0</span>
         </div>
-        <div style="margin-top: var(--space-md); display: flex; justify-content: space-between; flex-wrap: wrap;">
-          <a href="https://github.com/yadav-prakhar" target="_blank" rel="noopener" style="color: var(--text-secondary); text-decoration: none; font-size: 0.875rem;" title="GitHub">
-            <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle; margin-right:4px;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>GitHub
+        <div class="footer-social">
+          <a href="https://github.com/yadav-prakhar" target="_blank" rel="noopener" title="GitHub">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+            GitHub
           </a>
-          <a href="https://www.linkedin.com/in/prakhar-yadav-856772b6/" target="_blank" rel="noopener" style="color: var(--text-secondary); text-decoration: none; font-size: 0.875rem;" title="LinkedIn">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" style="vertical-align:middle; margin-right:4px;"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>LinkedIn
+          <a href="https://www.linkedin.com/in/prakhar-yadav-856772b6/" target="_blank" rel="noopener" title="LinkedIn">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+            LinkedIn
           </a>
-          <a href="https://x.com/CodewithP" target="_blank" rel="noopener" style="color: var(--text-secondary); text-decoration: none; font-size: 0.875rem;" title="X / Twitter">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" style="vertical-align:middle; margin-right:4px;"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.259 5.631 5.905-5.631zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>X
+          <a href="https://x.com/CodewithP" target="_blank" rel="noopener" title="X / Twitter">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.259 5.631 5.905-5.631zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            X
           </a>
-          <a href="https://prakhar.hashnode.dev/" target="_blank" rel="noopener" style="color: var(--text-secondary); text-decoration: none; font-size: 0.875rem;" title="Hashnode Blog">
-            <svg width="18" height="18" viewBox="0 0 337 337" fill="currentColor" style="vertical-align:middle; margin-right:4px;"><path d="M168.5 0C75.42 0 0 75.42 0 168.5S75.42 337 168.5 337 337 261.58 337 168.5 261.58 0 168.5 0zm.36 245.55a77.05 77.05 0 110-154.1 77.05 77.05 0 010 154.1z"/></svg>Blog
+          <a href="https://prakhar.hashnode.dev/" target="_blank" rel="noopener" title="Hashnode Blog">
+            <svg width="14" height="14" viewBox="0 0 337 337" fill="currentColor"><path d="M168.5 0C75.42 0 0 75.42 0 168.5S75.42 337 168.5 337 337 261.58 337 168.5 261.58 0 168.5 0zm.36 245.55a77.05 77.05 0 110-154.1 77.05 77.05 0 010 154.1z"/></svg>
+            Blog
           </a>
         </div>
       </div>
@@ -1765,7 +1924,7 @@ Everything is **on track** for the Thursday release.
       </div>
     </div>
     <div class="footer-bottom">
-      <div>Built by <a href="https://github.com/yadav-prakhar" target="_blank" rel="noopener">Prakhar Yadav</a> · MIT License</div>
+      <div>Built by <a href="https://github.com/yadav-prakhar" target="_blank" rel="noopener" style="color: var(--text-secondary);">Prakhar Yadav</a> · MIT License</div>
       <div>
         <a href="https://github.com/yadav-prakhar/markdown-sn-extension" target="_blank" rel="noopener" style="color: var(--text-muted);">⭐ Star on GitHub</a>
       </div>
@@ -1784,7 +1943,7 @@ Everything is **on track** for the Thursday release.
   // ── Theme Toggle ──────────────────────────────────────────────
   const root = document.documentElement;
   const themeBtn = document.getElementById('themeToggle');
-  const saved = localStorage.getItem('theme') || 'dark';
+  const saved = localStorage.getItem('theme') || 'light';
   root.setAttribute('data-theme', saved);
   themeBtn.textContent = saved === 'dark' ? '☀️' : '🌙';
 
@@ -1799,9 +1958,7 @@ Everything is **on track** for the Thursday release.
   // ── Mobile Nav ────────────────────────────────────────────────
   const hamburger = document.getElementById('hamburger');
   const navLinks = document.getElementById('navLinks');
-  hamburger.addEventListener('click', () => {
-    navLinks.classList.toggle('open');
-  });
+  hamburger.addEventListener('click', () => navLinks.classList.toggle('open'));
   navLinks.querySelectorAll('a').forEach(a => {
     a.addEventListener('click', () => navLinks.classList.remove('open'));
   });
@@ -1819,14 +1976,11 @@ Everything is **on track** for the Thursday release.
     document.getElementById('lightbox').classList.remove('active');
     document.body.style.overflow = '';
   };
-  document.addEventListener('keydown', e => {
-    if (e.key === 'Escape') closeLightbox();
-  });
+  document.addEventListener('keydown', e => { if (e.key === 'Escape') closeLightbox(); });
 
   // ── FAQ Accordion ─────────────────────────────────────────────
   window.toggleFaq = function(btn) {
-    const item = btn.closest('.faq-item');
-    item.classList.toggle('open');
+    btn.closest('.faq-item').classList.toggle('open');
   };
 
   // ── Alert Types Grid ──────────────────────────────────────────
@@ -1851,10 +2005,7 @@ Everything is **on track** for the Thursday release.
     card.style.borderLeftColor = a.border;
     card.style.color = a.text;
     card.innerHTML = `
-      <div class="alert-card-header">
-        <span>${a.emoji}</span>
-        <span>${a.name.toUpperCase()}</span>
-      </div>
+      <div class="alert-card-header"><span>${a.emoji}</span><span>${a.name.toUpperCase()}</span></div>
       <div class="alert-card-syntax">&gt; [!${a.type}]</div>
       <div class="alert-card-desc">${a.desc}</div>
     `;
@@ -1975,15 +2126,11 @@ OutOfMemoryError: GC overhead limit exceeded
 
   function convertDemo() {
     const input = demoInput.value;
-    demoCharCount.textContent = input.length + ' characters';
-    if (!input.trim()) {
-      demoOutput.textContent = '// Start typing Markdown on the left...';
-      return;
-    }
+    demoCharCount.textContent = input.length + ' chars';
+    if (!input.trim()) { demoOutput.textContent = '// Start typing Markdown on the left...'; return; }
     try {
       if (typeof window.markdownServicenow !== 'undefined' && window.markdownServicenow.convertMarkdownToServiceNow) {
-        const result = window.markdownServicenow.convertMarkdownToServiceNow(input);
-        demoOutput.textContent = result;
+        demoOutput.textContent = window.markdownServicenow.convertMarkdownToServiceNow(input);
       } else {
         demoOutput.textContent = '// Library loading... please wait.';
       }
@@ -1998,17 +2145,13 @@ OutOfMemoryError: GC overhead limit exceeded
     debounceTimer = setTimeout(convertDemo, 150);
   });
 
-  // Load default preset
   loadPreset('basic');
 
-  // ── Smooth scroll for nav links ───────────────────────────────
+  // ── Smooth scroll ─────────────────────────────────────────────
   document.querySelectorAll('a[href^="#"]').forEach(a => {
     a.addEventListener('click', e => {
       const target = document.querySelector(a.getAttribute('href'));
-      if (target) {
-        e.preventDefault();
-        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }
+      if (target) { e.preventDefault(); target.scrollIntoView({ behavior: 'smooth', block: 'start' }); }
     });
   });
 
@@ -2021,13 +2164,11 @@ OutOfMemoryError: GC overhead limit exceeded
         if (entry.isIntersecting) {
           const id = entry.target.getAttribute('id');
           navItems.forEach(a => {
-            a.style.color = a.getAttribute('href') === '#' + id
-              ? 'var(--text)'
-              : 'var(--text-secondary)';
+            a.classList.toggle('nav-active', a.getAttribute('href') === '#' + id);
           });
         }
       });
-    }, { threshold: 0.3, rootMargin: '-60px 0px -50% 0px' });
+    }, { threshold: 0.3, rootMargin: '-56px 0px -50% 0px' });
     sections.forEach(s => observer.observe(s));
   }
 


### PR DESCRIPTION
## Summary

- Complete visual overhaul of `docs/index.html` — new font stack, color palette, and layout style
- Switches default theme to **light** (warm cream) instead of dark
- All content, sections, and JavaScript functionality preserved

## Design Changes

| | Before | After |
|---|---|---|
| **Default theme** | Dark (GitHub-inspired) | Light (warm cream `#F9F6F1`) |
| **Fonts** | System UI / SF Mono | Instrument Serif + DM Sans + JetBrains Mono |
| **Accent color** | Blue/purple gradient | Terracotta `#C84B31` |
| **Feature cards** | Rounded emoji cards | Flat numbered grid (01–09) in bordered table |
| **Section headers** | Label text only | Mono tag + extending horizontal rule |
| **Hero stats** | Floating centered items | Bordered horizontal strip |
| **Buttons** | Pill shape (full radius) | Sharp rectangular (3px radius) |
| **FAQ** | Rounded card accordion | Hairline-border open/close list |

## Test plan

- [x] Open `docs/index.html` locally and verify the page renders correctly in light mode
- [x] Toggle dark mode and verify warm dark theme applies
- [x] Verify live demo converts markdown correctly (uses `lib/markdown-servicenow.js`)
- [x] Click screenshots to verify lightbox opens
- [x] Verify FAQ accordion opens/closes
- [x] Check responsive layout at mobile widths (≤640px) and tablet (≤960px)