### PR TITLE
fix: protect bare URLs from italic conversion on underscores

### DIFF
--- a/lib/markdown-servicenow.js
+++ b/lib/markdown-servicenow.js
@@ -353,6 +353,14 @@ code { color: crimson; background-color: #f1f1f1; padding-left: 4px; padding-rig
       return placeholder;
     });
 
+    // Protect bare URLs (not already inside a protected link)
+    text = text.replace(/https?:\/\/[^\s<>"'()\[\]{}]+/g, (match) => {
+      const placeholder = `\x00MDSNPROTECTED${index}\x00`;
+      protectedItems.push(match);
+      index++;
+      return placeholder;
+    });
+
     return { text, protectedItems };
   }
 

--- a/tests/fixtures/markdown-samples.js
+++ b/tests/fixtures/markdown-samples.js
@@ -22,6 +22,9 @@ export const markdownSamples = {
 
   // Links and images
   link: '[Link text](https://example.com)',
+  linkWithUnderscoreInUrl: '[API docs](https://myinstance.service-now.com/kb_article.do?sys_id=abc_123)',
+  linkWithUnderscoreInText: '[my_api_docs](https://example.com)',
+  bareUrlWithUnderscores: 'See https://some_api_service.example.com for docs',
   image: '![Alt text](https://example.com/image.png)',
 
   // Blockquotes

--- a/tests/unit/lib/markdown-links.test.js
+++ b/tests/unit/lib/markdown-links.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { markdownSamples } from '../../fixtures/markdown-samples.js';
+import * as markdownServicenow from '../../../lib/markdown-servicenow.js';
+
+const convert = (input) =>
+  markdownServicenow.convertMarkdownToServiceNow(input, { skipCodeTags: true, skipPrettyPrint: true });
+
+describe('Link Conversion', () => {
+  describe('Markdown link syntax', () => {
+    it('should convert a simple link', () => {
+      const output = convert(markdownSamples.link);
+      expect(output).toContain('<a href="https://example.com">Link text</a>');
+    });
+
+    it('should preserve underscores in link URL', () => {
+      const output = convert(markdownSamples.linkWithUnderscoreInUrl);
+      expect(output).not.toContain('<em>');
+      expect(output).toContain('sys_id=abc_123');
+      expect(output).toContain('<a href=');
+    });
+
+    it('should preserve underscores in link text', () => {
+      const output = convert(markdownSamples.linkWithUnderscoreInText);
+      expect(output).not.toContain('<em>');
+      expect(output).toContain('>my_api_docs<');
+    });
+
+    it('should handle link with two underscores in URL path', () => {
+      const output = convert('[text](https://example.com/foo_bar_baz)');
+      expect(output).not.toContain('<em>');
+      expect(output).toContain('href="https://example.com/foo_bar_baz"');
+    });
+
+    it('should handle link with _foo_ pattern in URL', () => {
+      const output = convert('[text](https://example.com/_foo_/bar)');
+      expect(output).not.toContain('<em>');
+      expect(output).toContain('/_foo_/');
+    });
+  });
+
+  describe('Bare URLs (regression: underscore broken as italic)', () => {
+    it('should preserve underscores in bare URL', () => {
+      const output = convert(markdownSamples.bareUrlWithUnderscores);
+      expect(output).not.toContain('<em>');
+      expect(output).toContain('https://some_api_service.example.com');
+    });
+
+    it('should preserve bare URL with two underscores forming italic pattern', () => {
+      const output = convert('Check https://api_v2_server.example.com for info');
+      expect(output).not.toContain('<em>');
+      expect(output).toContain('https://api_v2_server.example.com');
+    });
+
+    it('should preserve ServiceNow bare URL with sys_id', () => {
+      const output = convert('Link: https://myinstance.service-now.com/kb_view.do?sysparm_article=KB_001_foo_bar');
+      expect(output).not.toContain('<em>');
+      expect(output).toContain('KB_001_foo_bar');
+    });
+
+    it('should still convert italic text near a bare URL', () => {
+      const output = convert('Use _italic_ and https://example.com/api_v2 here');
+      expect(output).toContain('<em>italic</em>');
+      expect(output).toContain('https://example.com/api_v2');
+      expect(output).not.toContain('api<em>v2</em>');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Bare URLs (e.g. `https://some_api_service.com`) had underscores incorrectly converted to `<em>` tags when the URL contained two underscores forming an italic pattern (e.g. `_api_`)
- The existing `protectContent()` system already handled markdown link syntax `[text](url)`, but bare URLs were left unprotected — this is a regression of the fix in #7
- Added bare URL protection (`http`/`https`) as the final step in `protectContent()`, after markdown links are already replaced with placeholders

## Test plan

- [x] New test file `tests/unit/lib/markdown-links.test.js` with 9 tests
- [x] Covers: markdown links with underscores in URL/text, bare URLs with `_api_` patterns, ServiceNow `sys_id` URLs, mixed italic + bare URL content
- [x] Full test suite passes (250 tests, 0 failures)